### PR TITLE
Add content object metadata and custom time by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
     "esbonio.sphinx.confDir": "${workspaceFolder}/docs/source",
     "jupyter.widgetScriptSources": ["jsdelivr.com", "unpkg.com"],
     "prettier.prettierPath": "/usr/local/prettier",
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
     "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
     "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
     "python.formatting.provider": "black",

--- a/django_gcp/events/utils.py
+++ b/django_gcp/events/utils.py
@@ -60,6 +60,7 @@ def make_pubsub_message(
     https://stackoverflow.com/questions/73477187/why-do-gcp-pub-sub-messages-have-duplicated-message-id-and-publish-time-values
 
     :param Union[dict, list] data: JSON-serialisable data to form the body of the message
+    :param str subscription: a subscription path which indicates the subscription that caused this message to be delivered, eg 'projects/my-project/subscriptions/my-subscription-name'
     :param Union[dict, None] attributes: Dict of attributes to attach to the message. Contents must be flat, containing only string keys with string values.
     :param Union[str, None] message_id: An optional id for the message.
     :param Union[str, None] ordering_key: A string used to order messages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

# Summary

This release ensures that any `metadata` or `custom_time` attribute on the content object gets added to the blob on creation (or update) in google cloud, to avoid a second roundtrip to add metadata.

The method that adds this data can be overridden in a custom storage class to avoid adding it altogether or to add different data.

<!--- START AUTOGENERATED NOTES --->
# Contents ([#17](https://github.com/octue/django-gcp/pull/17))

### New features
- Add content object metadata and custom time by default

<!--- END AUTOGENERATED NOTES --->