### PR TITLE
Add default app config so task manager initialised correctly

### DIFF
--- a/django_gcp/__init__.py
+++ b/django_gcp/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "django_gcp.apps.DjangoGcpAppConfig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

# Summary

This fixes use with django < 4 where the default app config needs to be explicitly given by an app

<!--- START AUTOGENERATED NOTES --->
# Contents ([#18](https://github.com/octue/django-gcp/pull/18))

### Fixes
- Add default app config so task manager initialised correctly

<!--- END AUTOGENERATED NOTES --->