### PR TITLE
FIX: Add bucket name property to remedy backward compatibility

### DIFF
--- a/django_gcp/storage/gcloud.py
+++ b/django_gcp/storage/gcloud.py
@@ -135,6 +135,15 @@ class GoogleCloudStorage(CompressStorageMixin, Storage):
             self._bucket = self.client.bucket(self.settings.bucket_name)
         return self._bucket
 
+    @property
+    def bucket_name(self):
+        """The name of the bucket corresponding to this store
+
+        A convenience property referring to self.settings.bucket_name but here for backward compatibility
+        with django_storages and ease of general use
+        """
+        return self.settings.bucket_name
+
     def _normalize_name(self, name):
         """
         Normalizes the name so that paths like /path/to/ignored/../something.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

# Summary

<!--- START AUTOGENERATED NOTES --->
# Contents ([#19](https://github.com/octue/django-gcp/pull/19))

### Fixes
- Add bucket name property to remedy backward compatibility

<!--- END AUTOGENERATED NOTES --->