### PR TITLE
Disable enqueueing task using setting

### DIFF
--- a/django_gcp/exceptions.py
+++ b/django_gcp/exceptions.py
@@ -36,3 +36,7 @@ class AttemptedOverwriteError(Exception):
 
 class MissingBlobError(Exception):
     """Raised when attempting to access or copy a blob that is not present in GCS"""
+
+
+class IncompatibleSettingsError(ValueError):
+    """Raised when settings values are mutually exclusive"""

--- a/django_gcp/tasks/manager.py
+++ b/django_gcp/tasks/manager.py
@@ -50,9 +50,9 @@ class TaskManager:
         return getattr(settings, "GCP_TASKS_DELIMITER", "--")
 
     @property
-    def disable_execution(self):
-        """Return the GCP_TASKS_DISABLE_EXECUTION setting or default False"""
-        return getattr(settings, "GCP_TASKS_DISABLE_EXECUTION", False)
+    def disable_execute(self):
+        """Return the GCP_TASKS_DISABLE_EXECUTE setting or default False"""
+        return getattr(settings, "GCP_TASKS_DISABLE_EXECUTE", False)
 
     @property
     def domain(self):

--- a/django_gcp/tasks/manager.py
+++ b/django_gcp/tasks/manager.py
@@ -50,6 +50,11 @@ class TaskManager:
         return getattr(settings, "GCP_TASKS_DELIMITER", "--")
 
     @property
+    def disable_execution(self):
+        """Return the GCP_TASKS_DISABLE_EXECUTION setting or default False"""
+        return getattr(settings, "GCP_TASKS_DISABLE_EXECUTION", False)
+
+    @property
     def domain(self):
         """Return the GCP_TASKS_DOMAIN setting or a default"""
         _domain = getattr(settings, "GCP_TASKS_DOMAIN")

--- a/django_gcp/tasks/tasks.py
+++ b/django_gcp/tasks/tasks.py
@@ -170,7 +170,7 @@ class Task(metaclass=TaskMeta):
 
     def _send(self, task_kwargs, api_kwargs=None):
         if self.manager.disable_execute and self.manager.eager_execute:
-            raise IncompatibleSettingsError("disable_execute and eager_execute are mutually exclusive")
+            raise IncompatibleSettingsError("disable_execute and eager_execute should be mutually exclusive")
 
         if self.manager.disable_execute:
             return None

--- a/django_gcp/tasks/tasks.py
+++ b/django_gcp/tasks/tasks.py
@@ -83,13 +83,23 @@ class Task(metaclass=TaskMeta):
     deduplicate = False
 
     def enqueue(self, **kwargs):
-        """Invoke a task (place it onto a queue for processing)"""
+        """Enqueues the given task for processing, unless 'self.manager.disable_execution' is True.
+        If `manager.disable_execution` is True, this method returns None without enqueuing the task.
+        """
+        if self.manager.disable_execution:
+            return None
+
         return self._send(
             task_kwargs=kwargs,
         )
 
     def enqueue_later(self, when, **kwargs):
-        """Invoke a task (place it onto a queue for processing after some time delay)"""
+        """Invoke a task (place it onto a queue for processing after some time delay)
+        If `manager.disable_execution` is True, this method returns None without enqueuing the task.
+        """
+        if self.manager.disable_execution:
+            return None
+
         if isinstance(when, int):
             delay_in_seconds = when
         elif isinstance(when, timedelta):

--- a/docs/source/tasks_settings.rst
+++ b/docs/source/tasks_settings.rst
@@ -95,10 +95,10 @@ Type: ``boolean``
 
 Default: ``False``
 
-If set to true, tasks will not be enqueued for processing when their ``enqueue()`` and ``enqueue_later()``
-method is called. Instead, the method will simply return None without enqueuing the task, allowing for the
+If set to true, tasks will not be enqueued for processing when their ``enqueue()`` or ``enqueue_later()``
+methods are called. Instead, the method will simply return None without enqueuing the task, allowing for the
 disabling of task execution. This can be useful in scenarios where tasks need to be temporarily disabled or
 when testing/debugging task code.
 
-It is important to note that this setting only affects tasks that use the enqueue() method and that
-tasks can still be executed manually even if this setting is set to True.
+It is important to note that this setting only affect tasks when their ``enqueue()`` or ``enqueue_later()``
+methods are called and that tasks can still be executed manually even if this setting is set to True.

--- a/docs/source/tasks_settings.rst
+++ b/docs/source/tasks_settings.rst
@@ -90,7 +90,7 @@ debugging of tasks in local environments.
 
 
 ``GCP_TASKS_DISABLE_EXECUTE``
----------------------------
+-----------------------------
 Type: ``boolean``
 
 Default: ``False``

--- a/docs/source/tasks_settings.rst
+++ b/docs/source/tasks_settings.rst
@@ -87,3 +87,18 @@ If set to true, tasks will synchronously execute when their ``enqueue()`` method
 
 Whilst not generally useful in production, this can be quite helpful for straightforward
 debugging of tasks in local environments.
+
+
+``GCP_TASKS_DISABLE_EXECUTION``
+---------------------------
+Type: ``boolean``
+
+Default: ``False``
+
+If set to true, tasks will not be enqueued for processing when their ``enqueue()`` and ``enqueue_later()``
+method is called. Instead, the method will simply return None without enqueuing the task, allowing for the
+disabling of task execution. This can be useful in scenarios where tasks need to be temporarily disabled or
+when testing/debugging task code.
+
+It is important to note that this setting only affects tasks that use the enqueue() method and that
+tasks can still be executed manually even if this setting is set to True.

--- a/docs/source/tasks_settings.rst
+++ b/docs/source/tasks_settings.rst
@@ -89,7 +89,7 @@ Whilst not generally useful in production, this can be quite helpful for straigh
 debugging of tasks in local environments.
 
 
-``GCP_TASKS_DISABLE_EXECUTION``
+``GCP_TASKS_DISABLE_EXECUTE``
 ---------------------------
 Type: ``boolean``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.9.1"
+version = "0.9.2"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"

--- a/tests/test_tasks_enqueuing.py
+++ b/tests/test_tasks_enqueuing.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from django_gcp.events.utils import make_pubsub_message
-from django_gcp.exceptions import DuplicateTaskError, IncorrectTaskUsageError
+from django_gcp.exceptions import DuplicateTaskError, IncompatibleSettingsError, IncorrectTaskUsageError
 from django_gcp.tasks import OnDemandTask
 from gcp_pilot.mocker import patch_auth
 from google.api_core.exceptions import AlreadyExists
@@ -87,13 +87,13 @@ class TasksEnqueueingTest(SimpleTestCase):
         self.assertIn("error", response.json())
 
     def test_disable_enqueueing_with_a_setting(self):
-        """Assert that no task is enqueued if the GCP_TASKS_DISABLE_EXECUTION is true"""
+        """Assert that no task is enqueued if the GCP_TASKS_DISABLE_EXECUTE is true"""
         with patch_auth():
-            with patch("django_gcp.tasks.tasks.Task._send") as patched_send:
+            with patch("django_gcp.tasks.tasks.run_coroutine") as patched_send:
                 MyOnDemandTask().enqueue(a="1")
                 self.assertEqual(patched_send.call_count, 1)
 
-                with override_settings(GCP_TASKS_DISABLE_EXECUTION=True):
+                with override_settings(GCP_TASKS_DISABLE_EXECUTE=True):
                     MyOnDemandTask().enqueue(a="1")
                     MyPeriodicTask().enqueue(a="1")
                     MySubscriberTask().enqueue(a="1")
@@ -107,3 +107,7 @@ class TasksEnqueueingTest(SimpleTestCase):
                     FailingOnDemandTask().enqueue_later(a="1", when=10)
 
                     self.assertEqual(patched_send.call_count, 1)
+
+            with override_settings(GCP_TASKS_DISABLE_EXECUTE=True, GCP_TASKS_EAGER_EXECUTE=True):
+                with self.assertRaises(IncompatibleSettingsError):
+                    MyOnDemandTask().enqueue(a="1")

--- a/tests/test_tasks_enqueuing.py
+++ b/tests/test_tasks_enqueuing.py
@@ -8,7 +8,7 @@
 
 import json
 from unittest.mock import patch
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from django_gcp.events.utils import make_pubsub_message
 from django_gcp.exceptions import DuplicateTaskError, IncorrectTaskUsageError
@@ -16,7 +16,13 @@ from django_gcp.tasks import OnDemandTask
 from gcp_pilot.mocker import patch_auth
 from google.api_core.exceptions import AlreadyExists
 
-from tests.server.example.tasks import DeduplicatedOnDemandTask, MyOnDemandTask
+from tests.server.example.tasks import (
+    DeduplicatedOnDemandTask,
+    FailingOnDemandTask,
+    MyOnDemandTask,
+    MyPeriodicTask,
+    MySubscriberTask,
+)
 from .test_events_utils import DEFAULT_SUBSCRIPTION
 
 
@@ -79,3 +85,25 @@ class TasksEnqueueingTest(SimpleTestCase):
 
         self.assertEqual(500, response.status_code)
         self.assertIn("error", response.json())
+
+    def test_disable_enqueueing_with_a_setting(self):
+        """Assert that no task is enqueued if the GCP_TASKS_DISABLE_EXECUTION is true"""
+        with patch_auth():
+            with patch("django_gcp.tasks.tasks.Task._send") as patched_send:
+                MyOnDemandTask().enqueue(a="1")
+                self.assertEqual(patched_send.call_count, 1)
+
+                with override_settings(GCP_TASKS_DISABLE_EXECUTION=True):
+                    MyOnDemandTask().enqueue(a="1")
+                    MyPeriodicTask().enqueue(a="1")
+                    MySubscriberTask().enqueue(a="1")
+                    FailingOnDemandTask().enqueue(a="1")
+
+                    self.assertEqual(patched_send.call_count, 1)
+
+                    MyOnDemandTask().enqueue_later(a="1", when=10)
+                    MyPeriodicTask().enqueue_later(a="1", when=10)
+                    MySubscriberTask().enqueue_later(a="1", when=10)
+                    FailingOnDemandTask().enqueue_later(a="1", when=10)
+
+                    self.assertEqual(patched_send.call_count, 1)


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

# Summary

<!--- START AUTOGENERATED NOTES --->
# Contents ([#35](https://github.com/octue/django-gcp/pull/35))

### Enhancements
- Disable enqueueing the task using a setting
- Review changes

### Operations
- Bump version to 0.9.2

### Chores
- Update error message

### Other
- improve doc
- Fix rst underline

<!--- END AUTOGENERATED NOTES --->