### PR TITLE
Destroy Ganon, Rescue Princess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Located an extremely hard to understand bug related to the flushing of the cached existing value, in cases where multiple model objects are used simultaneously then one is refreshed from the database.

This was discovered and fixed in the WindQuest project then the fix ported over here. Kudos to @windpioneers for supporting open source and funding this work!

<!--- START AUTOGENERATED NOTES --->
# Contents ([#42](https://github.com/octue/django-gcp/pull/42))

### Fixes
- Cache values on model instead of common field instance

<!--- END AUTOGENERATED NOTES --->