### PR TITLE
FIX: Prevent permissions mode map from using None values from property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.10.2"
+version = "0.10.3"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#43](https://github.com/octue/django-gcp/pull/43))

### Fixes
- Prevent permissions mode map from using None values from property

<!--- END AUTOGENERATED NOTES --->