### PR TITLE
Allow tasks domain flag to be set dynamically in management command

### DIFF
--- a/docs/source/tasks_usage.rst
+++ b/docs/source/tasks_usage.rst
@@ -29,8 +29,30 @@ Note that this requires the task classes to be imported in ``tasks/__init__.py``
 
 Scheduling periodic tasks
 -------------------------
-Periodic tasks are triggered by cronjobs in Google Cloud Scheduler. To create these jobs, the ``create_scheduler_jobs``
-management command must be run.
+Periodic tasks are triggered by cronjobs in Google Cloud Scheduler.
+To create these resources, you may wish to manage them directly with
+terraform but it's possible to create the resources using the ``create_scheduler_jobs``
+action from the ``task_manager``` management command:
+
+.. code-block::
+
+    # Note: use the --task-domain flag to override the domain where tasks will get sent
+    python manage.py task manager create_scheduler_jobs
+
+.. attention::
+
+   To register these resources, your service account will need to have ``cloudscheduler.update`` permission. Here's how to apply that to a service account using terraform:
+
+   .. code-block::
+
+      # Allow django-gcp tasks to create periodic tasks in google cloud scheduler
+      resource "google_project_iam_binding" "cloudscheduler_admin" {
+        project = var.project
+        role    = "roles/cloudscheduler.admin"
+        members = [
+          "serviceAccount:your-service-account@your-project.iam.gserviceaccount.com",
+        ]
+      }
 
 Setting up subscriber tasks
 ---------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.11.5"
+version = "0.12.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#68](https://github.com/octue/django-gcp/pull/68))

### New features
- Allow tasks domain flag to be set dynamically

<!--- END AUTOGENERATED NOTES --->