### PR TITLE
Move blob utils to correct place

### DIFF
--- a/django_gcp/storage/__init__.py
+++ b/django_gcp/storage/__init__.py
@@ -1,6 +1,18 @@
 # TODO: Refactor tests to import members directly then remove this module export
 from . import gcloud
+from .blob_utils import BlobFieldMixin, get_blob, get_blob_name, get_path, get_signed_url, upload_blob
 from .gcloud import GoogleCloudFile, GoogleCloudMediaStorage, GoogleCloudStaticStorage, GoogleCloudStorage
 
-
-__all__ = ["GoogleCloudStorage", "GoogleCloudFile", "gcloud", "GoogleCloudMediaStorage", "GoogleCloudStaticStorage"]
+__all__ = [
+    "GoogleCloudStorage",
+    "GoogleCloudFile",
+    "gcloud",
+    "GoogleCloudMediaStorage",
+    "GoogleCloudStaticStorage",
+    "BlobFieldMixin",
+    "get_blob",
+    "get_blob_name",
+    "get_path",
+    "get_signed_url",
+    "upload_blob",
+]

--- a/django_gcp/storage/blob_utils.py
+++ b/django_gcp/storage/blob_utils.py
@@ -114,7 +114,7 @@ def get_signed_url(instance, field_name, expiration=None):
     return get_blob(instance, field_name).generate_signed_url(expiration=expiration)
 
 
-class BlobFieldModel:
+class BlobFieldMixin:
     """Mixin to a model to provide extra utility methods for processing of blobs"""
 
     def get_blob(self, field_name):

--- a/django_gcp/tasks/__init__.py
+++ b/django_gcp/tasks/__init__.py
@@ -1,16 +1,9 @@
 from .manager import TaskManager
 from .tasks import OnDemandTask, PeriodicTask, SubscriberTask
-from .utils import BlobFieldMixin, get_blob, get_blob_name, get_path, get_signed_url, upload_blob
 
 __all__ = (
     "PeriodicTask",
     "SubscriberTask",
     "OnDemandTask",
     "TaskManager",
-    "BlobFieldMixin",
-    "get_blob",
-    "get_blob_name",
-    "get_path",
-    "get_signed_url",
-    "upload_blob",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.14.0"
+version = "0.15.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
BREAKING-CHANGE: Moved erroneously-located blob utilities. Import blob utilities from django_gcp.storage not django_gcp.tasks.

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#75](https://github.com/octue/django-gcp/pull/75))

**IMPORTANT:** There is 1 breaking change.

### Refactoring
- 💥 **BREAKING CHANGE:** Move blob utils to correct place

---
# Upgrade instructions
<details>
<summary>💥 <b>Move blob utils to correct place</b></summary>

Moved erroneously-located blob utilities. Import blob utilities from django_gcp.storage not django_gcp.tasks.
</details>

<!--- END AUTOGENERATED NOTES --->