### PR TITLE
Debug

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,6 @@
         "python.testing.pytestEnabled": true,
         "python.testing.unittestEnabled": false,
         "terminal.integrated.defaultProfile.linux": "zsh",
-        "ruff.format.args": ["--line-length", "120"],
         "ruff.importStrategy": "fromEnvironment"
       },
 

--- a/django_gcp/storage/__init__.py
+++ b/django_gcp/storage/__init__.py
@@ -3,7 +3,7 @@ from . import gcloud
 from .blob_utils import BlobFieldMixin, get_blob, get_blob_name, get_path, get_signed_url
 from .fields import BlobField
 from .gcloud import GoogleCloudFile, GoogleCloudMediaStorage, GoogleCloudStaticStorage, GoogleCloudStorage
-from .operations import upload_blob
+from .operations import upload_blob, uploaded_blob
 
 __all__ = [
     "BlobField",
@@ -18,4 +18,5 @@ __all__ = [
     "get_path",
     "get_signed_url",
     "upload_blob",
+    "uploaded_blob",
 ]

--- a/django_gcp/storage/operations.py
+++ b/django_gcp/storage/operations.py
@@ -1,6 +1,8 @@
+from contextlib import contextmanager
 import datetime
 import logging
 
+from django.test.utils import override_settings
 from django.utils import timezone
 from google.cloud.exceptions import NotFound, PreconditionFailed
 from google.cloud.storage.blob import Blob
@@ -54,8 +56,9 @@ def upload_blob(
             instance,
             original_name=local_path,
             attributes=attributes,
-            allow_overwrite=allow_overwrite,
             existing_path=existing_path,
+            temporary_path=None,
+            allow_overwrite=allow_overwrite,
             bucket=field.storage.bucket,
         )
 
@@ -195,6 +198,38 @@ def get_signed_upload_url(bucket, blob_name, timedelta=None, max_size_bytes=None
     if max_size_bytes is not None:
         content_length_range = f"0,{max_size_bytes}"
         headers = kwargs.pop("headers", {})
-        headers["X-Goog-Content-Length-Range"]: content_length_range
+        headers["X-Goog-Content-Length-Range"] = content_length_range
+        kwargs["headers"] = headers
 
     return blob.generate_signed_url(expiration=timezone.now() + timedelta, method="PUT", **kwargs)
+
+
+@contextmanager
+def uploaded_blob(instance, field_name, local_path, destination_path=None, allow_overwrite=False, delete_on_exit=False):
+    """A context manager enabling the preparation of an instance with a blob uploaded from a local path.
+    Optionally override the destination path (the ultimate path of the blob within the destination bucket) and allow_overwrite parameter.
+
+    Usage:
+
+    ```py
+    my_instance = MyModel()
+    with uploaded_blob(my_instance, 'my_field', '/path/to/local/file') as field_value
+        my_instance.my_field = field_value
+        my_instance.save()
+    ```
+
+    """
+
+    with override_settings(GCP_STORAGE_OVERRIDE_BLOBFIELD_VALUE=True):
+        field_value = upload_blob(
+            instance,
+            field_name=field_name,
+            local_path=local_path,
+            destination_path=destination_path,
+            allow_overwrite=allow_overwrite,
+        )
+        try:
+            yield field_value
+        finally:
+            if delete_on_exit:
+                raise NotImplementedError("Deletion on exit is not yet implemented")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.17.1"
+version = "0.18.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"

--- a/tests/test_storage_fields.py
+++ b/tests/test_storage_fields.py
@@ -111,14 +111,25 @@ class TestBlobFieldAdmin(StorageOperationsMixin, TestCase):
             widget.signed_ingress_url.startswith("https://storage.googleapis.com/example-media-assets/_tmp")
         )
 
+    def test_full_clean_executes_in_overridden_context(self):
+        """Ensure that full_clean() can be legitimately called
+        on a model while in an overridden context
+        """
+
+        blob_name = self._prefix_blob_name("test_full_clean_executes_in_overridden_context.txt")
+        self._create_test_blob(self.bucket, blob_name, "")
+        with override_settings(GCP_STORAGE_OVERRIDE_BLOBFIELD_VALUE=True):
+            obj = ExampleBlobFieldModel(blob={"path": blob_name})
+            obj.full_clean()
+            obj.save()
+
     @override_settings(GCP_STORAGE_OVERRIDE_BLOBFIELD_VALUE=True)
     def test_change_view_loads_normally(self):
         """Ensure we can load a change view"""
 
         blob_name = self._prefix_blob_name("test_change_view_loads_normally.txt")
         self._create_test_blob(self.bucket, blob_name, "")
-        with override_settings(GCP_STORAGE_OVERRIDE_BLOBFIELD_VALUE=True):
-            obj = ExampleBlobFieldModel.objects.create(blob={"path": blob_name})
+        obj = ExampleBlobFieldModel.objects.create(blob={"path": blob_name})
 
         # Assert that the view loads
         response = self.client.get(get_admin_change_view_url(obj))


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#85](https://github.com/octue/django-gcp/pull/85))

### New features
- Add uploaded_blob context manager, useful for unit testing

### Fixes
- Allow field cleaning to happen inside an overridden context
- Correct implementation of headers for limiting content length range
- Make upload_blob woth with default destination path helper

### Operations
- Remove deprecated setting from devcontainer json

### Refactoring
- Remove redundant context in test

### Testing
- Test uploaded_blob context manager

### Uncategorised!
- Merge pull request #84 from octue/override-clean

<!--- END AUTOGENERATED NOTES --->