### PR TITLE
Add a `get_bucket_name` method to blob field utils

### DIFF
--- a/django_gcp/storage/blob_utils.py
+++ b/django_gcp/storage/blob_utils.py
@@ -92,6 +92,10 @@ class BlobFieldMixin:
     def get_bucket(cls, field_name):
         return cls._meta.get_field(field_name).storage.bucket
 
+    @classmethod
+    def get_bucket_name(cls, field_name):
+        return cls.get_bucket(field_name).name
+
     def get_console_url(self, field_name):
         """Get a URL to where the file resides in GCP cloud console"""
         return get_console_url(self, field_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-gcp"
-version = "0.18.2"
+version = "0.18.3"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = ["Tom Clark"]
 license = "MIT"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#88](https://github.com/octue/django-gcp/pull/88))

### Enhancements
- Add a get_bucket_name method to blob field utils

<!--- END AUTOGENERATED NOTES --->