### PR TITLE
BREAKING CHANGE: Migrate to Django 5.1+ STORAGES setting

### DIFF
--- a/django_gcp/storage/fields.py
+++ b/django_gcp/storage/fields.py
@@ -123,8 +123,8 @@ class BlobField(models.JSONField):
         kwargs["default"] = kwargs.pop("default", None)
         kwargs["help_text"] = kwargs.pop("help_text", "GCP cloud storage object")
 
-        # Note, if you want to define overrides, then use the GCP_STORAGE_EXTRA_STORES
-        # setting with a different key
+        # Note: store_key corresponds to a storage alias in the STORAGES setting.
+        # For example, store_key="versioned" would look up STORAGES["versioned"]["OPTIONS"]
         self.storage = GoogleCloudStorage(store_key=store_key)
 
         # We should consider if there's a good use case for customising the storage class:

--- a/django_gcp/storage/gcloud.py
+++ b/django_gcp/storage/gcloud.py
@@ -335,11 +335,14 @@ class GoogleCloudStorage(CompressStorageMixin, Storage):  # pylint: disable=abst
 
 
 class GoogleCloudMediaStorage(GoogleCloudStorage):  # pylint: disable=abstract-method
-    """Storage whose bucket name is taken from the GCP_STORAGE_MEDIA_NAME setting
+    """Storage for media files, configured via STORAGES['default']
+
+    This should be used as the BACKEND for the 'default' storage alias in Django's
+    STORAGES setting. Configuration options are passed via STORAGES['default']['OPTIONS'].
 
     This actually behaves exactly as a default instantiation of the base
-    ``GoogleCloudStorage`` class, but is there to make configuration more
-    explicit for first-timers.
+    ``GoogleCloudStorage`` class with store_key='media', but is there to make
+    configuration more explicit for first-timers.
 
     """
 
@@ -350,9 +353,12 @@ class GoogleCloudMediaStorage(GoogleCloudStorage):  # pylint: disable=abstract-m
 
 
 class GoogleCloudStaticStorage(GoogleCloudStorage):  # pylint: disable=abstract-method
-    """Storage defined with an appended bucket name (called "<bucket>-static")
+    """Storage for static files, configured via STORAGES['staticfiles']
 
-    We define that static files are stored in a different bucket than the (private) media files, which:
+    This should be used as the BACKEND for the 'staticfiles' storage alias in Django's
+    STORAGES setting. Configuration options are passed via STORAGES['staticfiles']['OPTIONS'].
+
+    We recommend storing static files in a different bucket than (private) media files, which:
         1. gives us less risk of accidentally setting private files as public
         2. allows us easier visual inspection in the console of what's private and what's public static
         3. allows us to set blanket public ACLs on the static bucket

--- a/django_gcp/storage/gcloud.py
+++ b/django_gcp/storage/gcloud.py
@@ -341,15 +341,15 @@ class GoogleCloudMediaStorage(GoogleCloudStorage):  # pylint: disable=abstract-m
     STORAGES setting. Configuration options are passed via STORAGES['default']['OPTIONS'].
 
     This actually behaves exactly as a default instantiation of the base
-    ``GoogleCloudStorage`` class with store_key='media', but is there to make
+    ``GoogleCloudStorage`` class with store_key='default', but is there to make
     configuration more explicit for first-timers.
 
     """
 
     def __init__(self, **overrides):
-        if overrides.pop("store_key", "media") != "media":
-            raise ValueError("You cannot instantiate GoogleCloudMediaStorage with a store_key other than 'media'")
-        super().__init__(store_key="media", **overrides)
+        if overrides.pop("store_key", "default") != "default":
+            raise ValueError("You cannot instantiate GoogleCloudMediaStorage with a store_key other than 'default'")
+        super().__init__(store_key="default", **overrides)
 
 
 class GoogleCloudStaticStorage(GoogleCloudStorage):  # pylint: disable=abstract-method
@@ -367,6 +367,6 @@ class GoogleCloudStaticStorage(GoogleCloudStorage):  # pylint: disable=abstract-
     """
 
     def __init__(self, **overrides):
-        if overrides.pop("store_key", "static") != "static":
-            raise ValueError("You cannot instantiate GoogleCloudStaticStorage with a store_key other than 'static'")
-        super().__init__(store_key="static", **overrides)
+        if overrides.pop("store_key", "staticfiles") != "staticfiles":
+            raise ValueError("You cannot instantiate GoogleCloudStaticStorage with a store_key other than 'staticfiles'")
+        super().__init__(store_key="staticfiles", **overrides)

--- a/django_gcp/storage/settings.py
+++ b/django_gcp/storage/settings.py
@@ -63,12 +63,13 @@ class StorageSettings:
 
     @property
     def _stores_settings(self):
-        """Get a complete dict of all stores defined in settings.py (media + static + extras)
+        """Get a complete dict of all stores defined in settings.py
 
-        Reads from Django's STORAGES setting (Django 5.1+) and maps storage aliases to store keys.
-        - 'default' alias maps to 'media' store key
-        - 'staticfiles' alias maps to 'static' store key
-        - Other aliases use their name as the store key
+        Reads from Django's STORAGES setting (Django 5.1+). The storage alias (key in STORAGES dict)
+        is used as the store_key. For example:
+        - STORAGES["default"] is accessed with store_key="default"
+        - STORAGES["staticfiles"] is accessed with store_key="staticfiles"
+        - STORAGES["my-custom"] is accessed with store_key="my-custom"
         """
         storages_config = getattr(django_settings, "STORAGES", {})
         all_stores = {}
@@ -79,18 +80,7 @@ class StorageSettings:
             # Only process django_gcp storage backends
             if "django_gcp.storage" in backend:
                 options = config.get("OPTIONS", {})
-
-                # Map Django's standard aliases to our internal store keys
-                if alias == "default":
-                    store_key = "media"
-                elif alias == "staticfiles":
-                    store_key = "static"
-                else:
-                    # For extra stores, use the alias as the store key
-                    # unless explicitly specified in OPTIONS
-                    store_key = options.pop("store_key", alias)
-
-                all_stores[store_key] = options
+                all_stores[alias] = options
 
         return all_stores
 

--- a/django_gcp/storage/settings.py
+++ b/django_gcp/storage/settings.py
@@ -63,14 +63,36 @@ class StorageSettings:
 
     @property
     def _stores_settings(self):
-        """Get a complete dict of all stores defined in settings.py (media + static + extras)"""
-        all_stores = {
-            "media": getattr(django_settings, "GCP_STORAGE_MEDIA", None),
-            "static": getattr(django_settings, "GCP_STORAGE_STATIC", None),
-            **getattr(django_settings, "GCP_STORAGE_EXTRA_STORES", {}),
-        }
+        """Get a complete dict of all stores defined in settings.py (media + static + extras)
 
-        return dict((k, v) for k, v in all_stores.items() if v is not None)
+        Reads from Django's STORAGES setting (Django 5.1+) and maps storage aliases to store keys.
+        - 'default' alias maps to 'media' store key
+        - 'staticfiles' alias maps to 'static' store key
+        - Other aliases use their name as the store key
+        """
+        storages_config = getattr(django_settings, "STORAGES", {})
+        all_stores = {}
+
+        for alias, config in storages_config.items():
+            backend = config.get("BACKEND", "")
+
+            # Only process django_gcp storage backends
+            if "django_gcp.storage" in backend:
+                options = config.get("OPTIONS", {})
+
+                # Map Django's standard aliases to our internal store keys
+                if alias == "default":
+                    store_key = "media"
+                elif alias == "staticfiles":
+                    store_key = "static"
+                else:
+                    # For extra stores, use the alias as the store key
+                    # unless explicitly specified in OPTIONS
+                    store_key = options.pop("store_key", alias)
+
+                all_stores[store_key] = options
+
+        return all_stores
 
     @property
     def _store_settings(self):
@@ -79,7 +101,9 @@ class StorageSettings:
             return self._stores_settings[self._store_key]
         except KeyError as e:
             raise ImproperlyConfigured(
-                f"Mismatch: specified store key '{self._store_key}' does not match 'media', 'static', or any store key defined in GCP_STORAGE_EXTRA_STORES"
+                f"Storage with key '{self._store_key}' not found in STORAGES setting. "
+                f"Available stores: {list(self._stores_settings.keys())}. "
+                f"Please ensure STORAGES['{self._store_key}'] or STORAGES['default'/'staticfiles'] is configured with a django_gcp.storage backend."
             ) from e
 
     def _handle_settings_changed(self, **kwargs):

--- a/docs/source/storage.rst
+++ b/docs/source/storage.rst
@@ -55,32 +55,98 @@ Setup Media and Static Storage
 ------------------------------
 
 The most common types of storage are for media and static files, using the storage backend.
-We derived a custom storage type for each, making it easier to name them.
+We provide custom storage classes for each, making it easier to configure them.
 
-In your ``settings.py`` file, do:
+In your ``settings.py`` file, configure the ``STORAGES`` setting (Django 5.1+):
 
 .. code-block:: python
 
-    # Set the default storage (for media files)
+    STORAGES = {
+        "default": {
+            "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+            "OPTIONS": {
+                "bucket_name": "app-assets-environment-media",  # Or whatever name you chose
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+            "OPTIONS": {
+                "bucket_name": "app-assets-environment-static",  # Or whatever name you chose
+            },
+        },
+    }
+
+    # Point the URLs to the store locations
+    #   You could customise the base URLs later with your own CDN, eg https://static.you.com
+    #   But that's only if you feel like being ultra fancy
+    MEDIA_URL = "https://storage.googleapis.com/app-assets-environment-media/"
+    MEDIA_ROOT = "/media/"
+    STATIC_URL = "https://storage.googleapis.com/app-assets-environment-static/"
+    STATIC_ROOT = "/static/"
+
+
+Migrating from Django <5.1
+---------------------------
+
+If you're upgrading from an earlier version of django-gcp that used Django <5.1, you'll need to migrate your settings
+from the old ``DEFAULT_FILE_STORAGE``, ``STATICFILES_STORAGE``, and ``GCP_STORAGE_*`` format to the new ``STORAGES`` format.
+
+**Before (Django <5.1):**
+
+.. code-block:: python
+
     DEFAULT_FILE_STORAGE = "django_gcp.storage.GoogleCloudMediaStorage"
     GCP_STORAGE_MEDIA = {
-        "bucket_name": "app-assets-environment-media" # Or whatever name you chose
+        "bucket_name": "my-media-bucket",
+        "location": "media/",
     }
 
-    # Set the static file storage
-    #   This allows `manage.py collectstatic` to automatically upload your static files
     STATICFILES_STORAGE = "django_gcp.storage.GoogleCloudStaticStorage"
     GCP_STORAGE_STATIC = {
-      "bucket_name": "app-assets-environment-static" # or whatever name you chose
+        "bucket_name": "my-static-bucket",
     }
 
-    # Point the urls to the store locations
-    #   You could customise the base URLs later with your own cdn, eg https://static.you.com
-    #   But that's only if you feel like being ultra fancy
-    MEDIA_URL = f"https://storage.googleapis.com/{GCP_STORAGE_MEDIA_NAME}/"
-    MEDIA_ROOT = "/media/"
-    STATIC_URL = f"https://storage.googleapis.com/{GCP_STORAGE_STATIC_NAME}/"
-    STATIC_ROOT = "/static/"
+    GCP_STORAGE_EXTRA_STORES = {
+        "versioned": {
+            "bucket_name": "my-versioned-bucket",
+        }
+    }
+
+**After (Django 5.1+):**
+
+.. code-block:: python
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+            "OPTIONS": {
+                "bucket_name": "my-media-bucket",
+                "location": "media/",
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+            "OPTIONS": {
+                "bucket_name": "my-static-bucket",
+            },
+        },
+        "versioned": {
+            "BACKEND": "django_gcp.storage.GoogleCloudStorage",
+            "OPTIONS": {
+                "bucket_name": "my-versioned-bucket",
+            },
+        },
+    }
+
+Key changes:
+
+- ``DEFAULT_FILE_STORAGE`` → ``STORAGES["default"]["BACKEND"]``
+- ``STATICFILES_STORAGE`` → ``STORAGES["staticfiles"]["BACKEND"]``
+- ``GCP_STORAGE_MEDIA`` → ``STORAGES["default"]["OPTIONS"]``
+- ``GCP_STORAGE_STATIC`` → ``STORAGES["staticfiles"]["OPTIONS"]``
+- ``GCP_STORAGE_EXTRA_STORES`` → additional entries in ``STORAGES`` dict
+
+Note that project-level settings like ``GCP_PROJECT_ID`` and ``GCP_CREDENTIALS`` remain at the root level of your settings file.
 
 
 Default and Extra stores
@@ -92,17 +158,28 @@ Default and Extra stores
 
       Any number of extra stores can be added, each corresponding to a different bucket in GCS.
 
-      You'll need to give each one a "storage key" to identify it. In your ``settings.py``, include extra stores as:
+      Simply add additional entries to the ``STORAGES`` dict. Each storage alias can be used to identify
+      the storage backend you want to use. In your ``settings.py``:
 
       .. code-block:: python
 
-         GCP_STORAGE_EXTRA_STORES = {
-             "my_fun_store_key": {
-                 "bucket_name": "all-the-fun-datafiles"
+         STORAGES = {
+             "default": {
+                 "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+                 "OPTIONS": {"bucket_name": "my-media-bucket"},
              },
-             "my_sad_store_key": {
-                 "bucket_name": "all-the-sad-datafiles"
-             }
+             "staticfiles": {
+                 "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+                 "OPTIONS": {"bucket_name": "my-static-bucket"},
+             },
+             "my-fun-store": {
+                 "BACKEND": "django_gcp.storage.GoogleCloudStorage",
+                 "OPTIONS": {"bucket_name": "all-the-fun-datafiles"},
+             },
+             "my-sad-store": {
+                 "BACKEND": "django_gcp.storage.GoogleCloudStorage",
+                 "OPTIONS": {"bucket_name": "all-the-sad-datafiles"},
+             },
          }
 
 
@@ -254,16 +331,21 @@ Works as a standard drop-in storage backend.
 Storage Settings Options
 ------------------------
 
-Each store can be set up with different options, passed within the dict given to ``GCP_STORAGE_MEDIA``, ``GCP_STORAGE_STATIC`` or within the dicts given to ``GCP_STORAGE_EXTRA_STORES``.
+Each store can be set up with different options, passed within the ``OPTIONS`` dict for each storage backend in the ``STORAGES`` setting.
 
 For example, to set the media storage up so that files go to a different location than the root of the bucket, you'd use:
 
 .. code-block:: python
 
-    GCP_STORAGE_MEDIA = {
-        "bucket_name": "app-assets-environment-media"
-        "location": "not/the/bucket/root/",
-        # ... and whatever other options you want
+    STORAGES = {
+        "default": {
+            "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+            "OPTIONS": {
+                "bucket_name": "app-assets-environment-media",
+                "location": "not/the/bucket/root/",
+                # ... and whatever other options you want
+            },
+        },
     }
 
 The full range of options (and their defaults, which apply to all stores) is as follows:

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -9,3 +9,40 @@ our `conventional commits tools <https://github/octue/conventional-commits>`_
 for completely automating code versions, release numbering and release history.
 
 So for a full version history, check our `releases page <https://github/octue/django-gcp/releases>`_.
+
+Breaking Changes in Next Release
+---------------------------------
+
+**Django 5.1+ STORAGES Setting Migration**
+
+This release drops support for Django <5.1 and migrates to Django's new ``STORAGES`` setting format.
+
+**What changed:**
+
+- **Minimum Django version**: Now requires Django >=5.1,<6.0 (was >=4.0,<5.1)
+- **Settings format**: The old ``DEFAULT_FILE_STORAGE``, ``STATICFILES_STORAGE``, ``GCP_STORAGE_MEDIA``, ``GCP_STORAGE_STATIC``, and ``GCP_STORAGE_EXTRA_STORES`` settings are no longer supported
+- **New format**: Use Django's ``STORAGES`` dict setting (introduced in Django 4.2, required in Django 5.1+)
+
+**Migration guide:**
+
+See the :ref:`storage` documentation for complete migration instructions. In summary:
+
+Old settings::
+
+    DEFAULT_FILE_STORAGE = "django_gcp.storage.GoogleCloudMediaStorage"
+    GCP_STORAGE_MEDIA = {"bucket_name": "my-media"}
+    STATICFILES_STORAGE = "django_gcp.storage.GoogleCloudStaticStorage"
+    GCP_STORAGE_STATIC = {"bucket_name": "my-static"}
+
+New settings::
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+            "OPTIONS": {"bucket_name": "my-media"},
+        },
+        "staticfiles": {
+            "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+            "OPTIONS": {"bucket_name": "my-static"},
+        },
+    }

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -22,6 +22,7 @@ This release drops support for Django <5.1 and migrates to Django's new ``STORAG
 - **Minimum Django version**: Now requires Django >=5.1,<6.0 (was >=4.0,<5.1)
 - **Settings format**: The old ``DEFAULT_FILE_STORAGE``, ``STATICFILES_STORAGE``, ``GCP_STORAGE_MEDIA``, ``GCP_STORAGE_STATIC``, and ``GCP_STORAGE_EXTRA_STORES`` settings are no longer supported
 - **New format**: Use Django's ``STORAGES`` dict setting (introduced in Django 4.2, required in Django 5.1+)
+- **BlobField store_key**: Must be updated to use Django's storage aliases (``"default"``, ``"staticfiles"``, etc.)
 
 **Migration guide:**
 
@@ -39,10 +40,24 @@ New settings::
     STORAGES = {
         "default": {
             "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
-            "OPTIONS": {"bucket_name": "my-media"},
+            "OPTIONS": {
+                "bucket_name": "my-media",
+                "base_url": "https://storage.googleapis.com/my-media/",
+            },
         },
         "staticfiles": {
             "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
-            "OPTIONS": {"bucket_name": "my-static"},
+            "OPTIONS": {
+                "bucket_name": "my-static",
+                "base_url": "https://storage.googleapis.com/my-static/",
+            },
         },
     }
+
+BlobField changes::
+
+    # OLD
+    blob = BlobField(store_key="media", ...)
+
+    # NEW
+    blob = BlobField(store_key="default", ...)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [{ include = "django_gcp" },]
 
 
 [tool.poetry.dependencies]
-Django = ">=4.0,<5.1"
+Django = ">=5.1,<6.0"
 python = ">=3.9,<4"
 django-app-settings = "^0.7.1"
 python-dateutil = "^2.8.2"

--- a/tests/server/example/models.py
+++ b/tests/server/example/models.py
@@ -163,7 +163,7 @@ class ExampleBlankBlobFieldModel(Model):
     category = CharField(max_length=20, blank=True, null=True)
     blob = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         blank=True,
         null=True,
         help_text="Shows typical behaviour of the blobfield, with name collision prevention so you should be able to change the file as many times as you like. The field is blankable (saving with no file selected should succeed).",
@@ -197,7 +197,7 @@ class ExampleBlobFieldModel(Model):
     #   Then the old field is removed (see migration 0003).
     blob = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="Shows typical behaviour of the blobfield, with name collision prevention so you should be able to change the file as many times as you like, but it is not blankable or nullable (attempt to save with no file selected to see validation error).",
     )
 
@@ -265,7 +265,7 @@ class ExampleCallbackBlobFieldModel(Model):
     activity = CharField(max_length=60, blank=True, null=True)
     blob = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         blank=True,
         null=True,
         on_change=my_on_change_callback,
@@ -292,7 +292,7 @@ class ExampleNeverOverwriteBlobFieldModel(Model):
     id = UUIDField(primary_key=True, default=uuid4, editable=False)
     blob = BlobField(
         get_destination_path=get_destination_path_from_id,
-        store_key="media",
+        store_key="default",
         overwrite_mode="never",
         help_text="You can create a model like this, but if you attempt to select a different file during update, you should see an exception. You need to override the widget to show read-only in this case.",
     )
@@ -316,17 +316,17 @@ class ExampleMultipleBlobFieldModel(Model):
 
     blob1 = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="The get_destination_path function gives these unique names",
     )
     blob2 = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="The get_destination_path function gives these unique names",
     )
     blob3 = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="The get_destination_path function gives these unique names",
     )
 
@@ -342,7 +342,7 @@ class ExamplePathValidationBlobFieldModel(Model):
     id = UUIDField(primary_key=True, default=uuid4, editable=False)
     blob = BlobField(
         get_destination_path=get_destination_path_and_validate,
-        store_key="media",
+        store_key="default",
         overwrite_mode="never",
         help_text="If you upload a file that doesn't end with .txt, you should see a validation error in the admin.",
     )
@@ -364,7 +364,7 @@ class ExampleReadOnlyBlobFieldModel(Model):
 
     example_read_only_blob = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="The widget should be read-only always",
         blank=True,  # So we can demo read-only behaviour
         null=True,  # in the admin without creating blobs
@@ -372,7 +372,7 @@ class ExampleReadOnlyBlobFieldModel(Model):
 
     example_create_only_blob = BlobField(
         get_destination_path=get_destination_path,
-        store_key="media",
+        store_key="default",
         help_text="The widget should be as normal for object addition, read-only in a change form",
         blank=True,  # So we can demo read-only behaviour
         null=True,  # in the admin without creating blobs
@@ -414,7 +414,7 @@ class ExampleUpdateAttributesBlobFieldModel(Model):
     blob = BlobField(
         get_destination_path=get_destination_path,
         update_attributes=update_attributes,
-        store_key="media",
+        store_key="default",
         blank=True,
         null=True,
         help_text="On save, metadata should be updated on the blob.",

--- a/tests/server/settings.py
+++ b/tests/server/settings.py
@@ -169,27 +169,24 @@ STORAGES = {
         "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
         "OPTIONS": {
             "bucket_name": "example-media-assets",
+            "base_url": "https://storage.googleapis.com/example-media-assets/",
         },
     },
     "staticfiles": {
         "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
         "OPTIONS": {
             "bucket_name": "example-static-assets",
+            "base_url": "https://storage.googleapis.com/example-static-assets/",
         },
     },
     "extra-versioned": {
         "BACKEND": "django_gcp.storage.GoogleCloudStorage",
         "OPTIONS": {
             "bucket_name": "example-extra-versioned-assets",
+            "base_url": "https://storage.googleapis.com/example-extra-versioned-assets/",
         },
     },
 }
-
-# Media and static URLs
-MEDIA_URL = "https://storage.googleapis.com/example-media-assets/"
-MEDIA_ROOT = "/media/"
-STATIC_URL = "https://storage.googleapis.com/example-static-assets/"
-STATIC_ROOT = "/static/"
 
 # STATIC FILES (FOR USING LOCAL STORAGE)
 # DEVELOPERS ONLY - Use these alternative settings for local development of CSS files,

--- a/tests/server/settings.py
+++ b/tests/server/settings.py
@@ -163,27 +163,48 @@ LOGGING = {
 # size, which is unwise if your users are not both trusted and competent
 GCP_STORAGE_BLOBFIELD_MAX_SIZE_BYTES = 0  # 32 * 1024 * 1024
 
-# MEDIA FILES
-DEFAULT_FILE_STORAGE = "django_gcp.storage.GoogleCloudMediaStorage"
-GCP_STORAGE_MEDIA = {"bucket_name": "example-media-assets"}
-MEDIA_URL = f"https://storage.googleapis.com/{GCP_STORAGE_MEDIA['bucket_name']}/"
-MEDIA_ROOT = "/media/"
+# STORAGES CONFIGURATION (Django 5.1+)
+STORAGES = {
+    "default": {
+        "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+        "OPTIONS": {
+            "bucket_name": "example-media-assets",
+        },
+    },
+    "staticfiles": {
+        "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+        "OPTIONS": {
+            "bucket_name": "example-static-assets",
+        },
+    },
+    "extra-versioned": {
+        "BACKEND": "django_gcp.storage.GoogleCloudStorage",
+        "OPTIONS": {
+            "bucket_name": "example-extra-versioned-assets",
+        },
+    },
+}
 
-# STATIC FILES (FOR USING THE CLOUD STORE)
-STATICFILES_STORAGE = "django_gcp.storage.GoogleCloudStaticStorage"
-GCP_STORAGE_STATIC = {"bucket_name": "example-static-assets"}
-STATIC_URL = f"https://storage.googleapis.com/{GCP_STORAGE_STATIC['bucket_name']}/"
+# Media and static URLs
+MEDIA_URL = "https://storage.googleapis.com/example-media-assets/"
+MEDIA_ROOT = "/media/"
+STATIC_URL = "https://storage.googleapis.com/example-static-assets/"
 STATIC_ROOT = "/static/"
 
 # STATIC FILES (FOR USING LOCAL STORAGE)
 # DEVELOPERS ONLY - Use these alternative settings for local development of CSS files,
 # to avoid collectstatic taking forever each time you change the CSS.
-# STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+# STORAGES = {
+#     "default": {
+#         "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+#         "OPTIONS": {"bucket_name": "example-media-assets"},
+#     },
+#     "staticfiles": {
+#         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+#     },
+# }
 # STATIC_URL = "/static/"
 # STATIC_ROOT = os.path.join(BASE_DIR, "static")
-
-# EXTRA STORES
-GCP_STORAGE_EXTRA_STORES = {"extra-versioned": {"bucket_name": "example-extra-versioned-assets"}}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This commit migrates django-gcp to use Django 5.1's STORAGES setting, dropping support for Django <5.1 and the deprecated DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings.

Changes:
- Update minimum Django version to >=5.1,<6.0
- Refactor StorageSettings to read from STORAGES dict instead of GCP_STORAGE_MEDIA/STATIC/EXTRA_STORES settings
- Update all test cases to use new STORAGES format
- Update storage.rst documentation with new examples and migration guide
- Add breaking changes notice to version_history.rst
- Update docstrings in storage classes to reference STORAGES setting

Migration required: Users must update their Django settings from the old GCP_STORAGE_* format to the new STORAGES dict format. See documentation for detailed migration instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#93](https://github.com/octue/django-gcp/pull/93))

### Refactoring
- Simplify storage alias mapping and add base_url support

### Other
- Migrate to Django 5.1+ STORAGES setting

<!--- END AUTOGENERATED NOTES --->