### PR TITLE
Eager execution correctly respects execute method

### DIFF
--- a/django_gcp/tasks/tasks.py
+++ b/django_gcp/tasks/tasks.py
@@ -178,7 +178,7 @@ class Task(metaclass=TaskMeta):
 
         payload = serialize(task_kwargs)
         if self.manager.eager_execute:
-            return self.run(**deserialize(payload))
+            return self.execute(payload)
 
         api_kwargs = api_kwargs or {}
         api_kwargs.update(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.22.3"
+version = "0.23.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
BREAKING-CHANGE: When using *Task.enqueue() and *Task.enqueue_later() with GCP_TASKS_EAGER_EXECUTE=True, the returned value will now be the status of the task handler response, rather than the calculated result itself. This allows consistent execution between eager and async tasks in cases where the public execute() method of the *Task class has been overridden

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#101](https://github.com/octue/django-gcp/pull/101))

**IMPORTANT:** There is 1 breaking change.

### Fixes
- 💥 **BREAKING CHANGE:** Eager execution correctly respects execute method

---
# Upgrade instructions
<details>
<summary>💥 <b>Eager execution correctly respects execute method</b></summary>

When using *Task.enqueue() and *Task.enqueue_later() with GCP_TASKS_EAGER_EXECUTE=True, the returned value will now be the status of the task handler response, rather than the calculated result itself. This allows consistent execution between eager and async tasks in cases where the public execute() method of the *Task class has been overridden
</details>

<!--- END AUTOGENERATED NOTES --->