### PR TITLE
Allow wrapping of execute() by subclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.23.0"
+version = "0.24.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/tests/test_tasks_enqueuing.py
+++ b/tests/test_tasks_enqueuing.py
@@ -104,3 +104,13 @@ class TasksEnqueueingTest(SimpleTestCase):
             with override_settings(GCP_TASKS_DISABLE_EXECUTE=True, GCP_TASKS_EAGER_EXECUTE=True):
                 with self.assertRaises(IncompatibleSettingsError):
                     MyOnDemandTask().enqueue(a="1")
+
+    def test_enqueueing_with_eager_execute(self):
+        """Assert that tasks are successfully executed if GCP_TASKS_EAGER_EXECUTE is true"""
+
+        with patch("tests.server.example.tasks.MyOnDemandTask.run", return_value=None) as patched_run:
+            with override_settings(GCP_TASKS_DISABLE_EXECUTE=False, GCP_TASKS_EAGER_EXECUTE=True):
+                result = MyOnDemandTask().enqueue(a="1")
+
+        self.assertIsNone(result)
+        patched_run.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#103](https://github.com/octue/django-gcp/pull/103))

**IMPORTANT:** There is 1 breaking change.

### New features
- 💥 **BREAKING CHANGE:** Allow wrapping of execute by subclasses

---
# Upgrade instructions
<details>
<summary>💥 <b>Allow wrapping of execute by subclasses</b></summary>

This makes a further change to the api of the execute() method following the prior release. Now, the raw result is returned by execute() instead of a result, status tuple. The execute() method now accepts **task_kwargs instead of a raw request body requiring deserialisation. Deserialization and error handling are now managed where they ought to be - in the view.
</details>

<!--- END AUTOGENERATED NOTES --->