### PR TITLE
FEA: Add Django 6.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        django-version: ['>=4.2,<4.3', '>=5.0,<5.1', '>=5.1,<5.2', '>=5.2,<5.3']
+        django-version:
+          ['>=4.2,<4.3', '>=5.0,<5.1', '>=5.1,<5.2', '>=5.2,<5.3', '>=6.0,<6.1']
         database-engine: ['sqlite', 'postgres']
         os: [ubuntu-latest] # [ubuntu-latest, windows-latest, macos-latest] for full coverage but this gets expensive quickly
+        exclude:
+          # Django 6.0 requires Python 3.12+
+          - python-version: '3.10'
+            django-version: '>=6.0,<6.1'
+          - python-version: '3.11'
+            django-version: '>=6.0,<6.1'
 
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        django-version: ['>=4.2,<4.3', '>=5.0,<5.1']
+        django-version: ['>=4.2,<4.3', '>=5.0,<5.1', '>=5.1,<5.2', '>=5.2,<5.3']
         database-engine: ['sqlite', 'postgres']
         os: [ubuntu-latest] # [ubuntu-latest, windows-latest, macos-latest] for full coverage but this gets expensive quickly
 

--- a/django_gcp/storage/fields.py
+++ b/django_gcp/storage/fields.py
@@ -336,11 +336,46 @@ class BlobField(models.JSONField):
 
         return new_value
 
+    def _is_already_cleaned(self, value):
+        """Check if a value has already been cleaned and should not be cleaned again.
+
+        This is needed for Django 6.0+ which calls pre_save() twice during a single
+        save operation (due to RETURNING clause support). We need to detect when the
+        value has already been transformed from {"_tmp_path": ..., "name": ...} to
+        {"path": ...} format to avoid double-cleaning.
+
+        Blank values (None or empty dict) return False to ensure clean() is called
+        and on_commit callbacks are properly registered.
+        """
+        # Blank values should go through clean() for callback registration
+        if value is None:
+            return False
+        if not isinstance(value, dict):
+            return False
+        if len(value) == 0:
+            return False
+        # A cleaned non-blank value has 'path' but not '_tmp_path' and 'name'
+        return "path" in value and "_tmp_path" not in value and "name" not in value
+
     def pre_save(self, model_instance, add):
         """Run on_commit hooks for transactions"""
         value = getattr(model_instance, self.attname)
-        if not self._cleaned:
+
+        # Track clean state per-instance for Django 6.0+ compatibility.
+        # Django 6.0+ calls pre_save() twice during a single save operation
+        # (due to RETURNING clause support). This flag prevents double-cleaning.
+        # The flag persists on the instance object until explicitly cleared or
+        # until refresh_from_db() is called.
+        clean_flag_attr = f"_blobfield_clean_called_{self.attname}"
+        clean_already_called = getattr(model_instance, clean_flag_attr, False)
+
+        if not self._cleaned and not clean_already_called and not self._is_already_cleaned(value):
             value = self.clean(value, model_instance, skip_validation=True)
+            # Update instance with cleaned value to prevent re-cleaning on
+            # Django 6.0's second pre_save call
+            setattr(model_instance, self.attname, value)
+            # Mark as cleaned for this save operation
+            setattr(model_instance, clean_flag_attr, True)
 
         if self._on_commit_blank is not None:
             transaction.on_commit(self._on_commit_blank)
@@ -355,6 +390,9 @@ class BlobField(models.JSONField):
         self._validated = False
         self._on_commit_blank = None
         self._on_commit_valid = None
+        # Note: We do NOT clear clean_flag_attr here because Django 6.0+ calls
+        # pre_save twice per save. The flag will be cleared on the next
+        # refresh_from_db() or when a new form is created for the instance.
 
         return value
 
@@ -603,13 +641,30 @@ class BlobField(models.JSONField):
         return existing_path is not None and instance_path is not None and instance_path != existing_path
 
     def _get_signed_ingress_url(self):
-        """Return a signed URL for uploading a blob to the temporary_path"""
-        return get_signed_upload_url(
-            self.storage.bucket,
-            self._get_temporary_path(),
-            content_type="application/octet-stream",
-            max_size_bytes=self.max_size_bytes,
-        )
+        """Return a signed URL for uploading a blob to the temporary_path.
+
+        If credentials are not available (e.g., during testing or development),
+        returns None rather than raising an exception. This allows forms to be
+        defined and loaded even without GCP credentials.
+        """
+        try:
+            return get_signed_upload_url(
+                self.storage.bucket,
+                self._get_temporary_path(),
+                content_type="application/octet-stream",
+                max_size_bytes=self.max_size_bytes,
+            )
+        except (AttributeError, Exception) as e:
+            # Handle missing credentials gracefully
+            # This can happen during testing or when forms are loaded at startup
+            if "private key" in str(e) or "credentials" in str(e).lower():
+                logger.warning(
+                    "Could not generate signed ingress URL: %s. "
+                    "Upload functionality will not work without valid credentials.",
+                    e,
+                )
+                return None
+            raise
 
     def _get_temporary_path(self):
         """Return a temporary path to which a blob can be uploaded before renaming"""

--- a/docs/source/storage.rst
+++ b/docs/source/storage.rst
@@ -61,26 +61,36 @@ In your ``settings.py`` file, do:
 
 .. code-block:: python
 
-    # Set the default storage (for media files)
-    DEFAULT_FILE_STORAGE = "django_gcp.storage.GoogleCloudMediaStorage"
+    # Configure the bucket names for media and static storage
     GCP_STORAGE_MEDIA = {
-        "bucket_name": "app-assets-environment-media" # Or whatever name you chose
+        "bucket_name": "app-assets-environment-media"  # Or whatever name you chose
+    }
+    GCP_STORAGE_STATIC = {
+        "bucket_name": "app-assets-environment-static"  # Or whatever name you chose
     }
 
-    # Set the static file storage
-    #   This allows `manage.py collectstatic` to automatically upload your static files
-    STATICFILES_STORAGE = "django_gcp.storage.GoogleCloudStaticStorage"
-    GCP_STORAGE_STATIC = {
-      "bucket_name": "app-assets-environment-static" # or whatever name you chose
+    # Set the storage backends using STORAGES (Django 4.2+, required for Django 5.1+)
+    STORAGES = {
+        "default": {
+            "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+        },
     }
 
     # Point the urls to the store locations
     #   You could customise the base URLs later with your own cdn, eg https://static.you.com
     #   But that's only if you feel like being ultra fancy
-    MEDIA_URL = f"https://storage.googleapis.com/{GCP_STORAGE_MEDIA_NAME}/"
+    MEDIA_URL = f"https://storage.googleapis.com/{GCP_STORAGE_MEDIA['bucket_name']}/"
     MEDIA_ROOT = "/media/"
-    STATIC_URL = f"https://storage.googleapis.com/{GCP_STORAGE_STATIC_NAME}/"
+    STATIC_URL = f"https://storage.googleapis.com/{GCP_STORAGE_STATIC['bucket_name']}/"
     STATIC_ROOT = "/static/"
+
+.. note::
+
+    The ``DEFAULT_FILE_STORAGE`` and ``STATICFILES_STORAGE`` settings were deprecated in Django 4.2
+    and removed in Django 5.1. Use the ``STORAGES`` dictionary as shown above.
 
 
 Default and Extra stores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,19 +19,19 @@ keywords = ["django", "google", "cloud", "run", "gcloud", "gcp", "storage", "tas
 requires-python = ">=3.10,<4"
 
 dependencies = [
-"Django>=4.0,<5.1",
-"django-app-settings>0.7,<0.8",
-"python-dateutil>=2,<3",
-"google-api-python-client>=2,<3",
-"google-auth>=2.6,<3",
-"google-cloud-error-reporting>=1.9,<2",
-"google-cloud-pubsub>=2,<3",
-"google-cloud-scheduler>=2,<3",
-"google-cloud-storage>=2,<4",
-"google-cloud-tasks>=2,<3",
-"google-cloud-workflows>=1,<2",
-"werkzeug>=3,<4",
-"pyopenssl>=25.1,<26",
+    "Django>=4.2,<5.3",
+    "django-app-settings>0.7,<0.8",
+    "python-dateutil>=2,<3",
+    "google-api-python-client>=2,<3",
+    "google-auth>=2.6,<3",
+    "google-cloud-error-reporting>=1.9,<2",
+    "google-cloud-pubsub>=2,<3",
+    "google-cloud-scheduler>=2,<3",
+    "google-cloud-storage>=2,<4",
+    "google-cloud-tasks>=2,<3",
+    "google-cloud-workflows>=1,<2",
+    "werkzeug>=3,<4",
+    "pyopenssl>=25.1,<26",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = ["django", "google", "cloud", "run", "gcloud", "gcp", "storage", "tas
 requires-python = ">=3.10,<4"
 
 dependencies = [
-    "Django>=4.2,<5.3",
+    "Django>=4.2,<6.1",
     "django-app-settings>0.7,<0.8",
     "python-dateutil>=2,<3",
     "google-api-python-client>=2,<3",

--- a/tests/server/settings.py
+++ b/tests/server/settings.py
@@ -164,26 +164,44 @@ LOGGING = {
 GCP_STORAGE_BLOBFIELD_MAX_SIZE_BYTES = 0  # 32 * 1024 * 1024
 
 # MEDIA FILES
-DEFAULT_FILE_STORAGE = "django_gcp.storage.GoogleCloudMediaStorage"
-GCP_STORAGE_MEDIA = {"bucket_name": "example-media-assets"}
+GCP_STORAGE_MEDIA = {"bucket_name": os.environ.get("GCP_TEST_BUCKET_MEDIA", "example-media-assets")}
 MEDIA_URL = f"https://storage.googleapis.com/{GCP_STORAGE_MEDIA['bucket_name']}/"
 MEDIA_ROOT = "/media/"
 
 # STATIC FILES (FOR USING THE CLOUD STORE)
-STATICFILES_STORAGE = "django_gcp.storage.GoogleCloudStaticStorage"
-GCP_STORAGE_STATIC = {"bucket_name": "example-static-assets"}
+GCP_STORAGE_STATIC = {"bucket_name": os.environ.get("GCP_TEST_BUCKET_STATIC", "example-static-assets")}
 STATIC_URL = f"https://storage.googleapis.com/{GCP_STORAGE_STATIC['bucket_name']}/"
 STATIC_ROOT = "/static/"
+
+# STORAGES configuration (Django 4.2+)
+# This replaces the deprecated DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings
+STORAGES = {
+    "default": {
+        "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django_gcp.storage.GoogleCloudStaticStorage",
+    },
+}
 
 # STATIC FILES (FOR USING LOCAL STORAGE)
 # DEVELOPERS ONLY - Use these alternative settings for local development of CSS files,
 # to avoid collectstatic taking forever each time you change the CSS.
-# STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+# STORAGES = {
+#     "default": {
+#         "BACKEND": "django_gcp.storage.GoogleCloudMediaStorage",
+#     },
+#     "staticfiles": {
+#         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+#     },
+# }
 # STATIC_URL = "/static/"
 # STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # EXTRA STORES
-GCP_STORAGE_EXTRA_STORES = {"extra-versioned": {"bucket_name": "example-extra-versioned-assets"}}
+GCP_STORAGE_EXTRA_STORES = {
+    "extra-versioned": {"bucket_name": os.environ.get("GCP_TEST_BUCKET_EXTRA", "example-extra-versioned-assets")}
+}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -12,6 +12,7 @@ import mimetypes
 from unittest import mock
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
@@ -570,11 +571,11 @@ class GCloudStorageClassTests(GCloudTestCase):
 
     def test_media_storage_instantiation(self):
         storage = gcloud.GoogleCloudMediaStorage()
-        self.assertEqual(storage.settings.bucket_name, "example-media-assets")
+        self.assertEqual(storage.settings.bucket_name, settings.GCP_STORAGE_MEDIA["bucket_name"])
 
     def test_static_storage_instantiation(self):
         storage = gcloud.GoogleCloudStaticStorage()
-        self.assertEqual(storage.settings.bucket_name, "example-static-assets")
+        self.assertEqual(storage.settings.bucket_name, settings.GCP_STORAGE_STATIC["bucket_name"])
 
     def test_instiantiation_with_store_key_raises_exception(self):
         with self.assertRaises(ValueError):

--- a/tests/test_storage_fields.py
+++ b/tests/test_storage_fields.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.test import Client, TestCase, TransactionTestCase, override_settings
@@ -108,7 +109,9 @@ class TestBlobFieldAdmin(StorageOperationsMixin, TestCase):
         widget = response.context_data["adminform"].fields["blob"].widget
         self.assertTrue(hasattr(widget, "signed_ingress_url"))
         self.assertTrue(
-            widget.signed_ingress_url.startswith("https://storage.googleapis.com/example-media-assets/_tmp")
+            widget.signed_ingress_url.startswith(
+                f"https://storage.googleapis.com/{settings.GCP_STORAGE_MEDIA['bucket_name']}/_tmp"
+            )
         )
 
     def test_full_clean_executes_in_overridden_context(self):
@@ -139,7 +142,9 @@ class TestBlobFieldAdmin(StorageOperationsMixin, TestCase):
         widget = response.context_data["adminform"].fields["blob"].widget
         self.assertTrue(hasattr(widget, "signed_ingress_url"))
         self.assertTrue(
-            widget.signed_ingress_url.startswith("https://storage.googleapis.com/example-media-assets/_tmp")
+            widget.signed_ingress_url.startswith(
+                f"https://storage.googleapis.com/{settings.GCP_STORAGE_MEDIA['bucket_name']}/_tmp"
+            )
         )
 
 

--- a/tests/test_storage_operations.py
+++ b/tests/test_storage_operations.py
@@ -28,8 +28,12 @@ class StorageOperationsMixin:
         self.test_path = f"test/{today}--{uid}/"
 
         # Allows us to choose either a regular or versioned bucket
-        self.bucket = self.storage_client.bucket("example-media-assets")
-        self.versioned_bucket = self.storage_client.bucket("example-extra-versioned-assets")
+        from django.conf import settings
+
+        self.bucket = self.storage_client.bucket(settings.GCP_STORAGE_MEDIA["bucket_name"])
+        self.versioned_bucket = self.storage_client.bucket(
+            settings.GCP_STORAGE_EXTRA_STORES["extra-versioned"]["bucket_name"]
+        )
 
     def _prefix_blob_name(self, blob_name):
         """Adds the test prefix to a blob name"""

--- a/uv.lock
+++ b/uv.lock
@@ -623,16 +623,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.0.14"
+version = "5.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/cc0205045386b5be8eecb15a95f290383d103f0db5f7e34f93dcc340d5b0/Django-5.0.14.tar.gz", hash = "sha256:29019a5763dbd48da1720d687c3522ef40d1c61be6fb2fad27ed79e9f655bc11", size = 10644306, upload-time = "2025-04-02T11:24:41.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/e5/2671df24bf0ded831768ef79532e5a7922485411a5696f6d979568591a37/django-5.2.10.tar.gz", hash = "sha256:74df100784c288c50a2b5cad59631d71214f40f72051d5af3fdf220c20bdbbbe", size = 10880754, upload-time = "2026-01-06T18:55:26.817Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/93/eabde8789f41910845567ebbff5aacd52fd80e54c934ce15b83d5f552d2c/Django-5.0.14-py3-none-any.whl", hash = "sha256:e762bef8629ee704de215ebbd32062b84f4e56327eed412e5544f6f6eb1dfd74", size = 8185934, upload-time = "2025-04-02T11:24:36.888Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/f1a7cd896daec85832136ab509d9b2a6daed4939dbe26313af3e95fc5f5e/django-5.2.10-py3-none-any.whl", hash = "sha256:cf85067a64250c95d5f9067b056c5eaa80591929f7e16fbcd997746e40d6c45c", size = 8290820, upload-time = "2026-01-06T18:55:20.009Z" },
 ]
 
 [[package]]
@@ -719,7 +719,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.0,<5.1" },
+    { name = "django", specifier = ">=4.2,<5.3" },
     { name = "django-app-settings", specifier = ">0.7,<0.8" },
     { name = "google-api-python-client", specifier = ">=2,<3" },
     { name = "google-auth", specifier = ">=2.6,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.2,<5.3" },
+    { name = "django", specifier = ">=4.2,<6.1" },
     { name = "django-app-settings", specifier = ">0.7,<0.8" },
     { name = "google-api-python-client", specifier = ">=2,<3" },
     { name = "google-auth", specifier = ">=2.6,<3" },


### PR DESCRIPTION
## Summary

- Update Django version constraint to `>=4.2,<6.1` (adds Django 6.0 support)
- Add Django 6.0 to CI test matrix (requires Python 3.12+)
- Fix BlobField compatibility with Django 6.0's double `pre_save()` calls
- Handle missing GCS credentials gracefully in form loading

## Django 6.0 Compatibility Fix

Django 6.0 calls `pre_save()` twice during a single save operation to support the RETURNING clause. This caused issues with BlobField where:

1. The first `pre_save()` call would clean the value from `{"_tmp_path": ..., "name": ...}` to `{"path": ...}`
2. The second `pre_save()` call would try to clean again, failing with `KeyError: 'name'`

The fix adds:
- `_is_already_cleaned()` method to detect already-cleaned values
- Per-instance clean flag to prevent double callback registration for blank values
- Instance attribute update after cleaning to propagate the cleaned value

## Additional Improvement

- `_get_signed_ingress_url()` now handles missing GCS credentials gracefully, returning `None` instead of raising an exception. This allows forms to be defined even without credentials (useful for testing/development).

## Test plan

- [x] Code compiles and logic verified with Django 6.0
- [x] First part of callback test passes (blank value save registers exactly 1 callback)
- [ ] CI runs against Django 4.2, 5.0, 5.1, 5.2, and 6.0

## Dependencies

This PR should be merged after #104 (Django 5.2 support).