### PR TITLE
DEP: Move werkzeug and pyopenssl out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ dependencies = [
 "google-cloud-storage>=2,<4",
 "google-cloud-tasks>=2,<3",
 "google-cloud-workflows>=1,<2",
-"werkzeug>=3,<4",
-"pyopenssl>=25.1,<26",
 ]
 
 [project.urls]
@@ -61,6 +59,8 @@ dev = [
 "throttle>=0.2.2,<0.3",
 "tox>=4.23.2,<5",
 "watchdog>=2.1.9,<3",
+"werkzeug>=3,<4",
+"pyopenssl>=25.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -560,9 +560,7 @@ dependencies = [
     { name = "google-cloud-storage" },
     { name = "google-cloud-tasks" },
     { name = "google-cloud-workflows" },
-    { name = "pyopenssl" },
     { name = "python-dateutil" },
-    { name = "werkzeug" },
 ]
 
 [package.dev-dependencies]
@@ -576,6 +574,7 @@ dev = [
     { name = "notebook" },
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
+    { name = "pyopenssl" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -588,6 +587,7 @@ dev = [
     { name = "throttle" },
     { name = "tox" },
     { name = "watchdog" },
+    { name = "werkzeug" },
 ]
 
 [package.metadata]
@@ -601,9 +601,7 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=2,<4" },
     { name = "google-cloud-tasks", specifier = ">=2,<3" },
     { name = "google-cloud-workflows", specifier = ">=1,<2" },
-    { name = "pyopenssl", specifier = ">=25.1,<26" },
     { name = "python-dateutil", specifier = ">=2,<3" },
-    { name = "werkzeug", specifier = ">=3,<4" },
 ]
 
 [package.metadata.requires-dev]
@@ -617,6 +615,7 @@ dev = [
     { name = "notebook", specifier = ">=6.5.3,<7" },
     { name = "pre-commit", specifier = ">=2.17.0,<3" },
     { name = "psycopg2-binary", specifier = ">=2.9.3,<3" },
+    { name = "pyopenssl", specifier = ">=25.1" },
     { name = "pytest", specifier = ">=8.3.4,<9" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7" },
@@ -629,6 +628,7 @@ dev = [
     { name = "throttle", specifier = ">=0.2.2,<0.3" },
     { name = "tox", specifier = ">=4.23.2,<5" },
     { name = "watchdog", specifier = ">=2.1.9,<3" },
+    { name = "werkzeug", specifier = ">=3,<4" },
 ]
 
 [[package]]


### PR DESCRIPTION
tl;dr - The package doesn't include a code path that uses them, and the inclusion creates security exposures.

## Motivation

Addresses several transitive CVEs:

- pyopenssl 26.0.0 fixes PYSEC-2026-2269 / GHSA-5pwr-322w-8jr4 (CVSS 9.8), and the `<26` cap blocks downstream projects from taking the fix. 
- The pin also transitively holds `cryptography` below 48 (its own advisory, GHSA-537c-gmf6-5ccf).

## Substance

This PR:

- removes `werkzeug` and `pyopenssl` from `[project].dependencies`
- adds them to the `dev` dependency group instead (pyopenssl uncapped), in case any local tooling still expects them — happy to drop them entirely if you'd prefer
- regenerates `uv.lock`

No source changes; the test suite is unaffected since the dev group still installs both.

## Analysis

Neither `werkzeug` nor `pyopenssl` is imported anywhere in `django_gcp` — a search of the tree finds them only in `pyproject.toml` and `uv.lock` (no `.py` file, no docs, no scripts reference them). Both arrived in 14266f43 ("ENH: Update tasks to enable use of emulator"), but the tasks emulator itself runs as an external container (`ghcr.io/aertje/cloud-tasks-emulator` in the devcontainer compose file). 
