### PR TITLE
FEA: Add in-app OIDC verification for workflow-called endpoints

### DIFF
--- a/django_gcp/workflows/__init__.py
+++ b/django_gcp/workflows/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import (
     WorkflowExecutionError,
     WorkflowNotFoundError,
 )
+from .oidc import verify_workflow_oidc_token, workflow_oidc_required
 from .workflows import Workflow, WorkflowExecution
 
 __all__ = [
@@ -17,4 +18,6 @@ __all__ = [
     "WorkflowExecutionError",
     "InvalidWorkflowArgumentsError",
     "WorkflowConfigurationError",
+    "verify_workflow_oidc_token",
+    "workflow_oidc_required",
 ]

--- a/django_gcp/workflows/oidc.py
+++ b/django_gcp/workflows/oidc.py
@@ -1,0 +1,85 @@
+"""In-app OIDC verification for Django endpoints called by GCP Cloud Workflows."""
+
+from functools import wraps
+import logging
+
+from django.conf import settings
+from django.http import JsonResponse
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+logger = logging.getLogger(__name__)
+
+
+def verify_workflow_oidc_token(request, allowed_service_account_emails=None):
+    """Verify that a request carries a valid GCP OIDC identity token from an allowed service account.
+
+    Cloud Workflows calls HTTP endpoints with ``auth: {type: OIDC, audience: <url>}``. Platform
+    IAM may already gate the intended route (for example an internal-ingress Cloud Run service),
+    but when the same application is also served publicly the token must be verified in-app:
+    valid signature, audience matching this request's absolute URI, and a verified email in the
+    allowed service account list.
+
+    :param request: the Django request to verify
+    :param allowed_service_account_emails: iterable of caller emails to accept; defaults to
+        ``settings.GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS`` (itself defaulting to empty,
+        which rejects every caller)
+    :return: a ``(claims, error)`` tuple — ``(claims, None)`` on success, or ``(None, JsonResponse)``
+        carrying the 401/403 to return
+    """
+    if allowed_service_account_emails is None:
+        allowed_service_account_emails = getattr(settings, "GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS", [])
+
+    authorization = request.headers.get("Authorization", "")
+    if not authorization.startswith("Bearer "):
+        return None, JsonResponse({"error": "Missing bearer token"}, status=401)
+
+    token = authorization.removeprefix("Bearer ")
+    audience = request.build_absolute_uri(request.path)
+
+    try:
+        claims = id_token.verify_oauth2_token(token, google_requests.Request(), audience=audience)
+    except ValueError as e:
+        logger.warning("Rejected workflow OIDC token: %s", e)
+        return None, JsonResponse({"error": "Invalid token"}, status=401)
+
+    if not claims.get("email_verified") or claims.get("email") not in allowed_service_account_emails:
+        logger.warning("Rejected workflow OIDC token for email %s", claims.get("email"))
+        return None, JsonResponse({"error": "Forbidden"}, status=403)
+
+    return claims, None
+
+
+def workflow_oidc_required(view_func=None, allowed_service_account_emails=None):
+    """Decorate a view to require a valid workflow OIDC token.
+
+    On success the verified claims are attached to the request as ``request.workflow_oidc_claims``
+    and the view runs; on failure the 401/403 ``JsonResponse`` is returned without calling the view.
+
+    Usable bare or with arguments::
+
+        @workflow_oidc_required
+        def my_view(request): ...
+
+        @workflow_oidc_required(allowed_service_account_emails=["workflows@my-project.iam.gserviceaccount.com"])
+        def my_view(request): ...
+
+    :param view_func: the view being decorated when used without arguments
+    :param allowed_service_account_emails: iterable of caller emails to accept; defaults to
+        ``settings.GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS``
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(request, *args, **kwargs):
+            claims, error = verify_workflow_oidc_token(request, allowed_service_account_emails)
+            if error is not None:
+                return error
+            request.workflow_oidc_claims = claims
+            return func(request, *args, **kwargs)
+
+        return wrapper
+
+    if view_func is not None:
+        return decorator(view_func)
+    return decorator

--- a/docs/source/workflows_usage.rst
+++ b/docs/source/workflows_usage.rst
@@ -290,6 +290,35 @@ Best practices
 7. **Define workflows in IaC**: Keep workflow definitions (YAML) in version-controlled Terraform/infrastructure code,
    not in Django.
 
+Verifying calls made by workflows
+---------------------------------
+
+Multi-step workflows often need to call back into Django between steps (for example to fetch
+state a Cloud Run job cannot return). Cloud Workflows can authenticate those calls with an
+OIDC identity token (``auth: {type: OIDC, audience: <url>}``); platform IAM may gate the
+intended route, but if the same application is also served publicly you must verify the token
+in-app as well. ``django_gcp`` provides both a view decorator and the underlying function:
+
+.. code-block:: python
+
+    from django_gcp.workflows import workflow_oidc_required
+
+    @workflow_oidc_required
+    def pending_items(request):
+        # request.workflow_oidc_claims carries the verified token claims
+        return JsonResponse({"pending": [...]})
+
+Verification requires a valid signature, an audience exactly matching the request's absolute
+URI, and a verified email in the allowed caller list, configured as:
+
+.. code-block:: python
+
+    GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS = ["workflows@my-project.iam.gserviceaccount.com"]
+
+With the setting absent every caller is rejected. Pass ``allowed_service_account_emails`` to
+the decorator (or to ``verify_workflow_oidc_token(request)`` directly) to override the setting
+per-endpoint.
+
 Limitations
 -----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.25.1"
+version = "0.26.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.26.0"
+version = "0.27.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.27.0"
+version = "0.26.0"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/tests/test_workflows_oidc.py
+++ b/tests/test_workflows_oidc.py
@@ -1,0 +1,142 @@
+# Disables for testing:
+# pylint: disable=missing-docstring
+
+import json
+from unittest.mock import patch
+
+from django.http import JsonResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from django_gcp.workflows import verify_workflow_oidc_token, workflow_oidc_required
+
+ALLOWED_EMAIL = "workflows@test-project.iam.gserviceaccount.com"
+
+
+def _claims(email=ALLOWED_EMAIL, email_verified=True):
+    return {"email": email, "email_verified": email_verified}
+
+
+@override_settings(GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS=[ALLOWED_EMAIL])
+class VerifyWorkflowOidcTokenTest(SimpleTestCase):
+    """Tests for verify_workflow_oidc_token."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _request(self, token="a-token"):
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {token}"} if token else {}
+        return self.factory.get("/workflows/some-endpoint/", **headers)
+
+    def test_missing_bearer_token_is_401(self):
+        claims, error = verify_workflow_oidc_token(self._request(token=None))
+
+        self.assertIsNone(claims)
+        self.assertEqual(error.status_code, 401)
+
+    def test_invalid_token_is_401(self):
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", side_effect=ValueError("bad token")):
+            claims, error = verify_workflow_oidc_token(self._request())
+
+        self.assertIsNone(claims)
+        self.assertEqual(error.status_code, 401)
+
+    def test_unverified_email_is_403(self):
+        with patch(
+            "django_gcp.workflows.oidc.id_token.verify_oauth2_token",
+            return_value=_claims(email_verified=False),
+        ):
+            claims, error = verify_workflow_oidc_token(self._request())
+
+        self.assertIsNone(claims)
+        self.assertEqual(error.status_code, 403)
+
+    def test_unlisted_service_account_is_403(self):
+        with patch(
+            "django_gcp.workflows.oidc.id_token.verify_oauth2_token",
+            return_value=_claims(email="someone-else@test-project.iam.gserviceaccount.com"),
+        ):
+            claims, error = verify_workflow_oidc_token(self._request())
+
+        self.assertIsNone(claims)
+        self.assertEqual(error.status_code, 403)
+
+    def test_valid_token_returns_claims(self):
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims()):
+            claims, error = verify_workflow_oidc_token(self._request())
+
+        self.assertIsNone(error)
+        self.assertEqual(claims["email"], ALLOWED_EMAIL)
+
+    def test_audience_is_the_request_absolute_uri(self):
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims()) as mock_verify:
+            verify_workflow_oidc_token(self._request())
+
+        audience = mock_verify.call_args.kwargs["audience"]
+        self.assertTrue(audience.endswith("/workflows/some-endpoint/"))
+        self.assertTrue(audience.startswith("http"))
+
+    def test_explicit_allowed_list_overrides_settings(self):
+        other = "other@test-project.iam.gserviceaccount.com"
+
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims(email=other)):
+            claims, error = verify_workflow_oidc_token(self._request(), allowed_service_account_emails=[other])
+
+        self.assertIsNone(error)
+        self.assertEqual(claims["email"], other)
+
+
+class VerifyWorkflowOidcTokenDefaultSettingsTest(SimpleTestCase):
+    """Without GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS defined, every caller is rejected."""
+
+    def test_absent_setting_rejects_every_caller(self):
+        request = RequestFactory().get("/workflows/some-endpoint/", HTTP_AUTHORIZATION="Bearer a-token")
+
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims()):
+            claims, error = verify_workflow_oidc_token(request)
+
+        self.assertIsNone(claims)
+        self.assertEqual(error.status_code, 403)
+
+
+@override_settings(GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS=[ALLOWED_EMAIL])
+class WorkflowOidcRequiredTest(SimpleTestCase):
+    """Tests for the workflow_oidc_required view decorator."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _request(self, token="a-token"):
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {token}"} if token else {}
+        return self.factory.get("/workflows/some-endpoint/", **headers)
+
+    def test_bare_decorator_runs_the_view_and_attaches_claims(self):
+        @workflow_oidc_required
+        def view(request):
+            return JsonResponse({"email": request.workflow_oidc_claims["email"]})
+
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims()):
+            response = view(self._request())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)["email"], ALLOWED_EMAIL)
+
+    def test_failed_verification_short_circuits_the_view(self):
+        @workflow_oidc_required
+        def view(request):  # pragma: no cover - must not run
+            raise AssertionError("view should not be called")
+
+        response = view(self._request(token=None))
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_decorator_with_arguments_overrides_allowed_list(self):
+        other = "other@test-project.iam.gserviceaccount.com"
+
+        @workflow_oidc_required(allowed_service_account_emails=[other])
+        def view(request):
+            return JsonResponse({"ok": True})
+
+        with patch("django_gcp.workflows.oidc.id_token.verify_oauth2_token", return_value=_claims(email=other)):
+            response = view(self._request())
+
+        self.assertEqual(response.status_code, 200)

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.27.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.25.1"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Multi-step Cloud Workflows often call back into the Django app between steps (a Cloud Run job can't return values to the workflow that ran it). Those calls authenticate with an OIDC identity token (`auth: {type: OIDC, audience: <url>}`) — but platform IAM alone only gates the intended route, and when the same application is served publicly elsewhere the token must be verified in-app too. This promotes windquest's implementation (windpioneers/windquest#2593, [review thread](https://github.com/windpioneers/windquest/pull/2593#discussion_r3957966232)) into `django_gcp.workflows` so every project shares one:

- `verify_workflow_oidc_token(request, allowed_service_account_emails=None)` — requires a Bearer token with a valid signature, an audience exactly matching the request's absolute URI, and a verified email in the allowed list; returns `(claims, None)` or `(None, JsonResponse 401/403)`.
- `workflow_oidc_required` — view decorator over the same check (bare or with an `allowed_service_account_emails` override), attaching claims as `request.workflow_oidc_claims`.
- New setting `GCP_WORKFLOWS_INVOKER_SERVICE_ACCOUNT_EMAILS` (default absent ⇒ every caller rejected).
- Docs section in `workflows_usage.rst`; 11 new tests (full workflow suite passes); version 0.25.1 → 0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--- START AUTOGENERATED NOTES --->
# Contents ([#109](https://github.com/octue/django-gcp/pull/109))

### New features
- Add in-app OIDC verification for workflow-called endpoints

### Operations
- Bump version

### Reversions
- Restore the 0.26.0 version bump

<!--- END AUTOGENERATED NOTES --->