### PR TITLE
OPS: Fix the cd release job and modernise its actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,31 +11,22 @@ jobs:
   release:
     if: '${{ github.event.pull_request.merged == true }}'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: 3.13
-
       - name: Get package version
         id: get-package-version
-        run: echo "package_version=$(uv version --short)" >> $GITHUB_OUTPUT
+        run: echo "package_version=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: Create release
-        uses: actions/create-release@v1.1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
-        with:
-          tag_name: ${{ steps.get-package-version.outputs.package_version }}
-          release_name: ${{ github.event.pull_request.title }}
-          body: ${{ github.event.pull_request.body }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+          RELEASE_BODY: ${{ github.event.pull_request.body }}
+        run: gh release create "${{ steps.get-package-version.outputs.package_version }}" --title "$RELEASE_TITLE" --notes "$RELEASE_BODY"
 
   publish:
     needs: release
@@ -49,14 +40,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
+          enable-cache: false
           python-version: 3.13
 
       - name: Build a binary wheel and a source tarball
         run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.26.0"
+version = "0.26.1"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.26.0"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
The `cd` run for #109 created the 0.26.0 GitHub release but **never published to PyPI**: the `release` job installs nothing, so `setup-uv`'s post-step cache save errored (`Cache path .../setup-uv-cache does not exist`), failing the job *after* `Create release` succeeded — which skipped the dependent `publish` job. 0.25.1 met the same fate (PyPI's latest is 0.25.0; both exist only as git tags).

Fixes, covering all of the run's annotations:

- **release job**: drops `setup-uv` entirely — the version is read straight from `pyproject.toml` with grep — and creates the release via `gh release create` instead of the archived `actions/create-release@v1.1.4` (the source of the node20 and `set-output` deprecation warnings). PR title/body are passed through env vars so shell metacharacters in them are inert; the job declares `contents: write` explicitly.
- **publish job**: `setup-uv@v5` → `@v10` (node24) with `enable-cache: false` (nothing worth caching in a once-per-merge run — and the same post-step failure mode would otherwise mark the run red after a successful publish), `pypi-publish` → v1.14.2.
- Version → **0.26.1** so merging this exercises the fixed pipeline end to end and gives PyPI its first release since 0.25.0. (0.26.0 stays git-tag-only — windquest already pins that tag, so nothing depends on backfilling it.)

<!--- START AUTOGENERATED NOTES --->
# Contents ([#110](https://github.com/octue/django-gcp/pull/110))

### Operations
- Fix the cd release job and modernise its actions

<!--- END AUTOGENERATED NOTES --->