### PR TITLE
OPS: Pin setup-uv to its exact tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: false
           python-version: 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-gcp"
-version = "0.26.1"
+version = "0.26.2"
 description = "Utilities to run Django on Google Cloud Platform"
 authors = [{name="Tom Clark"}]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "django-gcp"
-version = "0.26.1"
+version = "0.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
The 0.26.1 `cd` run created the release but publish failed in action download: `Unable to resolve action astral-sh/setup-uv@v10`. The repo's tags show why — floating major tags stop after v7 (`v8`/`v9`/`v10` bare don't exist; only exact tags like `v10.0.1` do). Pinned to `v10.0.1`.

Version → 0.26.2 so merging this exercises the fixed publish leg end to end; PyPI should then get its first release since 0.25.0. (0.26.0/0.26.1 remain git-tag-only, which nothing depends on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--- START AUTOGENERATED NOTES --->
# Contents ([#111](https://github.com/octue/django-gcp/pull/111))

### Operations
- Pin setup-uv to its exact tag; no floating v10 exists

<!--- END AUTOGENERATED NOTES --->